### PR TITLE
Tunnel fixes

### DIFF
--- a/app/extension/PacketTunnelProvider.swift
+++ b/app/extension/PacketTunnelProvider.swift
@@ -33,9 +33,10 @@ class PacketTunnelProvider: NEPacketTunnelProvider {
         super.init()
         if #available(iOS 16, *) {
             // the memory limit in the PacketTunnelProvider is 50mib in iOS 16, 17, 18
-            // the binary and go runtime take a part of that
+            // the binary and go runtime take about 30mib of that, leaving at most about 20mib for the sdk and tunnel provider
+            // since the limit is a soft limit, take ~80% of the available for the SDK
             // see https://forums.developer.apple.com/forums/thread/73148?page=2
-            SdkSetMemoryLimit(24 * 1024 * 1024)
+            SdkSetMemoryLimit(16 * 1024 * 1024)
         } else {
             // note provider is also disabled for these
             SdkSetMemoryLimit(4 * 1024 * 1024)

--- a/app/network/Shared/ViewModels/VPNManager.swift
+++ b/app/network/Shared/ViewModels/VPNManager.swift
@@ -82,36 +82,13 @@ class VPNManager {
             DispatchQueue.main.async {
                 self.updateTunnel()
                 
+                // note this makes it impossible to turn off the vpn from settings
+                // until it's possible to tell whether the tunnel ended from user preference or crash,
+                // we won't be able to support the settings without compromising reliability of the tunnel
                 if !tunnelStarted {
-                    // the user can manually stop the tunnel in settings
-                    // in this case, make sure we turn it off until the user starts it manually again
-//                    self.stopVpnTunnel()
-                    
-                    NETunnelProviderManager.loadAllFromPreferences { (managers, error) in
-                        if let _ = error {
-                            return
-                        }
-                        
-                        guard let tunnelManager = managers?.first else {
-                            return
-                        }
-                        
-                        // on ios, the user can manually stop the tunnel outside of the app by checking off the vpn setting
-                        // detect this case by looking at whether the tunnel stopped with error or normally
-                        tunnelManager.connection.fetchLastDisconnectError { error in
-                            if let error = error {
-                                print("[tunnel]disconnect error: \(error.localizedDescription)")
-                                
-                                // the tunnel stopped unexpectedly. Sync with state.
-                                self.tunnelRequestStatus = .none
-                                self.updateVpnService()
-                            } else {
-                                // the tunnel stopped normally e.g. the user turned off the tunnel
-                                self.stopVpnTunnel()
-                            }
-                        }
-                    }
-                    
+                    // the tunnel stopped unexpectedly. Sync with state.
+                    self.tunnelRequestStatus = .none
+                    self.updateVpnService()
                 }
             }
         })


### PR DESCRIPTION
We can't tell extension crash from the user turning off the vpn in settings. Err on the side of the most reliable tunnel.

Adjust extension memory targets.
